### PR TITLE
Add prefecture name to form submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This project demonstrates a simple LINE Bot that sends a link to a web form when
 - Uses the `@line/bot-sdk` and `express` packages.
 - Handles LINE `follow` events to send a form link containing the LINE user ID.
 - Serves a basic HTML form at `/form`.
-- The form collects the driver's name, prefecture code, vehicle availability and desired compensation.
+- The form collects the driver's name, prefecture code and name, vehicle availability and desired compensation.
 - On form submission, the bot sends a confirmation message back to the user.
 
 ## Setup

--- a/index.js
+++ b/index.js
@@ -120,10 +120,10 @@ app.get('/form', (req, res) => {
 
 // handle form submission
 app.post('/submit', async (req, res) => {
-  const { userId, name, prefectureCode, hasVehicle, reward } = req.body;
-  console.log('Form submitted:', { userId, name, prefectureCode, hasVehicle, reward });
+  const { userId, name, prefectureCode, prefecture, hasVehicle, reward } = req.body;
+  console.log('Form submitted:', { userId, name, prefectureCode, prefecture, hasVehicle, reward });
 
-  if (userId && name && prefectureCode && hasVehicle && reward) {
+  if (userId && name && prefectureCode && prefecture && hasVehicle && reward) {
     const vehicleText = hasVehicle === 'yes' ? 'あり' : 'なし';
     const confirmationMessage = `${name}様、エントリーありがとうございます！/nお住まいの地域に該当する案件をお探ししています。`;
 

--- a/src/templates.js
+++ b/src/templates.js
@@ -23,7 +23,7 @@ function getFormHtml(userId = '') {
       <input type="text" name="name" required>
 
       <label>居住地</label>
-      <select name="prefectureCode" required>
+      <select id="prefectureSelect" name="prefectureCode" required>
         <option value="01">北海道</option>
         <option value="02">青森県</option>
         <option value="03">岩手県</option>
@@ -72,6 +72,7 @@ function getFormHtml(userId = '') {
         <option value="46">鹿児島県</option>
         <option value="47">沖縄県</option>
       </select>
+      <input type="hidden" name="prefecture" id="prefecture">
 
       <label>車両の有無:</label>
       <select name="hasVehicle" required>
@@ -82,9 +83,18 @@ function getFormHtml(userId = '') {
       <label>報酬希望:</label>
       <input type="text" name="reward" required>
 
-      <button type="submit">送信</button>
+</button>
     </form>
   </div>
+  <script>
+    const select = document.getElementById('prefectureSelect');
+    const hidden = document.getElementById('prefecture');
+    function updatePrefecture() {
+      hidden.value = select.options[select.selectedIndex].text;
+    }
+    select.addEventListener('change', updatePrefecture);
+    updatePrefecture();
+  </script>
 </body>
 </html>`;
 }


### PR DESCRIPTION
## Summary
- add prefecture name field to HTML form
- send both prefecture name and code on submission
- capture and log prefecture name in the server
- update docs to mention new field

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6849a3797b40832b8bf9fcbc363a5fb7