### PR TITLE
Add GAS submission

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This project demonstrates a simple LINE Bot that sends a link to a web form when
 2. Set the following environment variables:
    - `LINE_CHANNEL_SECRET`
    - `LINE_CHANNEL_ACCESS_TOKEN`
+   - `GAS_URL` pointing to your Google Apps Script web app
    - Optional: `PORT` for the server (defaults to `3000`).
 3. Start the server:
    ```bash


### PR DESCRIPTION
## Summary
- add utility `sendToSpreadsheet` to post form data to GAS
- update form submission endpoint to push the received data
- mention `GAS_URL` environment variable in README

## Testing
- `npm test` *(fails: no test specified)*
- `bash test.sh` *(fails: .env file missing)*

------
https://chatgpt.com/codex/tasks/task_e_6849ac692858832bb8a6688b8bde8a30