### PR TITLE
Disable psych test, add Gemini prompt control

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This project demonstrates a simple LINE Bot that sends a link to a web form when
    - `LINE_CHANNEL_ACCESS_TOKEN`
    - `GAS_URL` pointing to your Google Apps Script web app
    - `GEMINI_API_KEY` for Google Gemini
+   - Optional: `GEMINI_SYSTEM_PROMPT` to customize Gemini's system prompt
    - `BOOKING_URL` URL the user is directed to when accepting a deal
    - Optional: `PORT` for the server (defaults to `3000`).
 3. Start the server:

--- a/src/handlers.js
+++ b/src/handlers.js
@@ -1,16 +1,14 @@
 import { createFormLinkMessage } from './messages.js';
 import { generateGeminiReply } from './gemini.js';
 
-// In-memory store to track progress of the psychological test for each user
-const userStates = {};
-
-// Simple psychological test questions
-const psychQuestions = [
-  '今、誰にも見られてないとしたら「何をしてみたい」ですか？',
-  'この世界から「1つだけ」消せるとしたら、何を消しますか？',
-  'あなたの親のことをどう思いますか？',
-  '全てのことに等しく意味があると思いますか？'
-];
+// ------ Psychological test feature (temporarily disabled) ------
+// const userStates = {};
+// const psychQuestions = [
+//   '今、誰にも見られてないとしたら「何をしてみたい」ですか？',
+//   'この世界から「1つだけ」消せるとしたら、何を消しますか？',
+//   'あなたの親のことをどう思いますか？',
+//   '全てのことに等しく意味があると思いますか？'
+// ];
 
 function createHandleEvent(client) {
   return async function handleEvent(event) {
@@ -18,28 +16,28 @@ function createHandleEvent(client) {
 
     if (event.type === 'follow') {
       const userId = event.source.userId;
-      // Start psychological test
-      userStates[userId] = 0;
-      console.log('Starting psychological test for new follower:', userId);
-      return client.replyMessage(event.replyToken, [{ type: 'text', text: psychQuestions[0] }]);
+      const link = `https://customer-service-hjly.onrender.com/form?userId=${userId}`;
+      console.log('Sending form link to new follower:', userId);
+      const messages = [createFormLinkMessage(link, '友達追加ありがとうございます！')];
+      return client.replyMessage(event.replyToken, messages);
     }
 
     if (event.type === 'message' && event.message.type === 'text') {
       const userId = event.source.userId;
-      if (userStates[userId] !== undefined) {
-        const step = userStates[userId];
-        if (step + 1 < psychQuestions.length) {
-          // Ask next question
-          userStates[userId] = step + 1;
-          return client.replyMessage(event.replyToken, [{ type: 'text', text: psychQuestions[step + 1] }]);
-        } else {
-          // End of test -> send form link
-          delete userStates[userId];
-          const link = `https://customer-service-hjly.onrender.com/form?userId=${userId}`;
-          const messages = [createFormLinkMessage(link, '心理テストへのご回答ありがとうございました！')];
-          return client.replyMessage(event.replyToken, messages);
-        }
-      }
+      // if (userStates[userId] !== undefined) {
+      //   const step = userStates[userId];
+      //   if (step + 1 < psychQuestions.length) {
+      //     // Ask next question
+      //     userStates[userId] = step + 1;
+      //     return client.replyMessage(event.replyToken, [{ type: 'text', text: psychQuestions[step + 1] }]);
+      //   } else {
+      //     // End of test -> send form link
+      //     delete userStates[userId];
+      //     const link = `https://customer-service-hjly.onrender.com/form?userId=${userId}`;
+      //     const messages = [createFormLinkMessage(link, '心理テストへのご回答ありがとうございました！')];
+      //     return client.replyMessage(event.replyToken, messages);
+      //   }
+      // }
       try {
         const reply = await generateGeminiReply(event.message.text);
         const messages = [{ type: 'text', text: reply || 'No response' }];


### PR DESCRIPTION
## Summary
- comment out the psychological test code
- allow overriding Gemini's system prompt via environment variable and helper
- document `GEMINI_SYSTEM_PROMPT` environment variable
- send the form link again whenever a user follows the LINE bot

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node index.js` *(fails: Cannot find package 'dotenv' imported from index.js)*

------
https://chatgpt.com/codex/tasks/task_e_686258457cd8832b96c07ed9c2c748be