### PR TITLE
Improve follow message

### DIFF
--- a/src/handlers.js
+++ b/src/handlers.js
@@ -18,7 +18,12 @@ function createHandleEvent(client) {
       const userId = event.source.userId;
       const link = `https://customer-service-hjly.onrender.com/form?userId=${userId}`;
       console.log('Sending form link to new follower:', userId);
-      const messages = [createFormLinkMessage(link, '友達追加ありがとうございます！')];
+      const messages = [createFormLinkMessage(
+        link,
+        '友達追加ありがとうございます！',
+        'すぐにお仕事紹介を希望ならこちらから👇🏻\nたった1分で完了',
+        '▶ フォームを開く'
+      )];
       return client.replyMessage(event.replyToken, messages);
     }
 

--- a/src/messages.js
+++ b/src/messages.js
@@ -1,12 +1,17 @@
-function createFormLinkMessage(link, prefix = '') {
+function createFormLinkMessage(
+  link,
+  prefix = '',
+  text = '以下のフォームから情報を入力してください。',
+  buttonLabel = 'フォームを開く'
+) {
   return {
     type: 'template',
     altText: 'お客様サポートフォーム',
     template: {
       type: 'buttons',
-      text: `${prefix}\n以下のフォームから情報を入力してください。`,
+      text: [prefix, text].filter(Boolean).join('\n'),
       actions: [
-        { type: 'uri', label: 'フォームを開く', uri: link }
+        { type: 'uri', label: buttonLabel, uri: link }
       ]
     }
   };


### PR DESCRIPTION
## Summary
- make form link message configurable
- show a clear call to action when a user follows the bot

## Testing
- `node --check src/messages.js`
- `node --check src/handlers.js`


------
https://chatgpt.com/codex/tasks/task_e_68692c0cd0fc832e9033719870b6244f